### PR TITLE
Fix openai module version to 0.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 hy
 hyrule
 sqlitedict
-openai[datalib]
+openai[datalib]==0.28
 tomli
 jaro-winkler
 tiktoken


### PR DESCRIPTION
Hello, thanks for your code, I didn't make it completely work yet, but I will make PR for the change that I must do to make it work.

Based on https://github.com/openai/openai-python/discussions/742#discussioncomment-7544918 it looks like openai module last version need some migration, but it's still possible to use the previous version for now.

Feel free to reject or correct a PR if needed.

Cheers